### PR TITLE
feat: serve prebuilt static HTML pages at build time

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/bootstrap.tsx"></script>
+    <script prerender type="module" src="/src/bootstrap.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "postbuild": "node ./scripts/generate-sitemap.mjs",
+    "postbuild": "node ./scripts/generate-sitemap.mjs && node ./scripts/verify-prerender.mjs",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -98,6 +98,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.51.0",
-    "vite": "^6.3.3"
+    "vite": "^6.3.3",
+    "vite-prerender-plugin": "^0.5.13"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       vite:
         specifier: ^6.3.3
         version: 6.4.2(@types/node@24.12.4)(jiti@1.21.7)(yaml@2.9.0)
+      vite-prerender-plugin:
+        specifier: ^0.5.13
+        version: 0.5.13(vite@6.4.2(@types/node@24.12.4)(jiti@1.21.7)(yaml@2.9.0))
 
 packages:
 
@@ -1761,6 +1764,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
@@ -1867,6 +1873,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1989,6 +2002,19 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2011,6 +2037,10 @@ packages:
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -2360,6 +2390,10 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
@@ -2578,6 +2612,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2630,6 +2667,9 @@ packages:
     resolution: {integrity: sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2691,6 +2731,9 @@ packages:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
 
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
@@ -2698,6 +2741,9 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3136,6 +3182,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-code-frame@1.3.0:
+    resolution: {integrity: sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3157,6 +3206,14 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  stack-trace@1.0.0:
+    resolution: {integrity: sha512-H6D7134xi6qONvh7ZHKgviXf+rd3vhGBSvebPZCaUkd8zvQ+7PtDw6CljPTe4cXWNf2IKZGNqw6VJXSb9IgBpA==}
+    engines: {node: '>=20.0.0'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3374,6 +3431,11 @@ packages:
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
+
+  vite-prerender-plugin@0.5.13:
+    resolution: {integrity: sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==}
+    peerDependencies:
+      vite: 5.x || 6.x || 7.x || 8.x
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -5006,6 +5068,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
@@ -5130,6 +5194,16 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -5236,6 +5310,24 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5257,6 +5349,8 @@ snapshots:
   embla-carousel@8.6.0: {}
 
   emoji-regex@10.6.0: {}
+
+  entities@4.5.0: {}
 
   environment@1.1.0: {}
 
@@ -5768,6 +5862,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  he@1.2.0: {}
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
@@ -5984,6 +6080,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kolorist@1.8.0: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -6046,6 +6144,10 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.23.0: {}
@@ -6101,9 +6203,18 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node-releases@2.0.46: {}
 
   normalize-path@3.0.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   object-assign@4.1.1: {}
 
@@ -6593,6 +6704,10 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-code-frame@1.3.0:
+    dependencies:
+      kolorist: 1.8.0
+
   slash@3.0.0: {}
 
   slice-ansi@7.1.2:
@@ -6611,6 +6726,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  stack-trace@1.0.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -6896,6 +7015,16 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  vite-prerender-plugin@0.5.13(vite@6.4.2(@types/node@24.12.4)(jiti@1.21.7)(yaml@2.9.0)):
+    dependencies:
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      node-html-parser: 6.1.13
+      simple-code-frame: 1.3.0
+      source-map: 0.7.6
+      stack-trace: 1.0.0
+      vite: 6.4.2(@types/node@24.12.4)(jiti@1.21.7)(yaml@2.9.0)
 
   vite@6.4.2(@types/node@24.12.4)(jiti@1.21.7)(yaml@2.9.0):
     dependencies:

--- a/scripts/verify-prerender.mjs
+++ b/scripts/verify-prerender.mjs
@@ -1,0 +1,69 @@
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { PRERENDER_ROUTES } from "../src/seo/prerenderRoutes.mjs";
+
+const distDir = path.resolve(process.cwd(), "dist");
+
+const routeFiles = PRERENDER_ROUTES.map((route) => ({
+  route,
+  file:
+    route === "/"
+      ? path.join(distDir, "index.html")
+      : path.join(distDir, route.slice(1), "index.html"),
+}));
+
+let failed = false;
+
+for (const { route, file } of routeFiles) {
+  let html;
+  let size;
+  try {
+    html = await readFile(file, "utf8");
+    size = (await stat(file)).size;
+  } catch {
+    console.error(`FAIL ${route}: missing ${path.relative(distDir, file)}`);
+    failed = true;
+    continue;
+  }
+
+  const hasTitle = /<title>[^<]+<\/title>/i.test(html);
+  const hasDescription = /<meta[^>]+name=["']description["'][^>]*>/i.test(
+    html,
+  );
+  const hasBundle = /\/assets\/bootstrap-[^"]+\.js/.test(html);
+  const hasPrerenderedMarkup =
+    html.includes('id="root"') &&
+    (html.includes("<main") || html.includes("container-custom"));
+
+  if (size < 5000) {
+    console.error(`FAIL ${route}: HTML file too small (${size} bytes)`);
+    failed = true;
+    continue;
+  }
+
+  if (!hasTitle || !hasDescription) {
+    console.error(`FAIL ${route}: missing SEO title or description meta tag`);
+    failed = true;
+    continue;
+  }
+
+  if (!hasBundle) {
+    console.error(`FAIL ${route}: missing client bundle script tag`);
+    failed = true;
+    continue;
+  }
+
+  if (!hasPrerenderedMarkup) {
+    console.error(`FAIL ${route}: missing expected prerendered page markup`);
+    failed = true;
+    continue;
+  }
+
+  console.log(`OK   ${route}: ${size} bytes prebuilt HTML`);
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log(`All ${routeFiles.length} prebuilt routes verified.`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,9 @@ function App() {
           <Route path="for-companies" element={<ForCompanies />} />
           <Route path="events" element={<Events />} />
         </Route>
+        <Route path="/about" element={<Layout switchLanguage={switchLanguage} />}>
+          <Route index element={<About />} />
+        </Route>
         <Route path="/privacy-policy" element={<PrivacyPolicy />} />
         <Route path="/imprint" element={<Imprint />} />
       </Routes>

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -1,16 +1,104 @@
 import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
-import { HelmetProvider } from "react-helmet-async";
+import {
+  HelmetProvider,
+  type FilledContext,
+  type HelmetServerState,
+} from "react-helmet-async";
 import App from "./App";
 import "./index.css";
+import { PRERENDER_ROUTES } from "./seo/prerenderRoutes.mjs";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <HelmetProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </HelmetProvider>
-  </StrictMode>,
-);
+function Root() {
+  return (
+    <StrictMode>
+      <HelmetProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </HelmetProvider>
+    </StrictMode>
+  );
+}
+
+if (typeof window !== "undefined") {
+  const target = document.getElementById("root");
+  if (!target) {
+    throw new Error("Root element #root not found");
+  }
+
+  if (import.meta.env.DEV) {
+    createRoot(target).render(<Root />);
+  } else {
+    hydrateRoot(target, <Root />);
+  }
+}
+
+function extractTitle(helmet: HelmetServerState): string | undefined {
+  const match = helmet.title.toString().match(/<title[^>]*>([^<]*)<\/title>/i);
+  return match?.[1];
+}
+
+function extractHeadElements(
+  helmet: HelmetServerState,
+): Set<{ type: string; props: Record<string, string> }> {
+  const elements = new Set<{ type: string; props: Record<string, string> }>();
+  const html = [helmet.meta.toString(), helmet.link.toString()].join("\n");
+  const tagRegex = /<(meta|link)\s+([^>]+?)\/?>/gi;
+
+  let tagMatch: RegExpExecArray | null;
+  while ((tagMatch = tagRegex.exec(html)) !== null) {
+    const type = tagMatch[1].toLowerCase();
+    const attrString = tagMatch[2];
+    const props: Record<string, string> = {};
+    const attrRegex =
+      /([\w:.-]+)(?:=(?:"([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
+
+    let attrMatch: RegExpExecArray | null;
+    while ((attrMatch = attrRegex.exec(attrString)) !== null) {
+      props[attrMatch[1]] =
+        attrMatch[2] ?? attrMatch[3] ?? attrMatch[4] ?? "";
+    }
+
+    elements.add({ type, props });
+  }
+
+  return elements;
+}
+
+export async function prerender(data: { url: string }) {
+  const { renderToString } = await import("react-dom/server");
+  const { StaticRouter } = await import("react-router-dom/server");
+  const { parseLinks } = await import("vite-prerender-plugin/parse");
+  const helmetContext: FilledContext = {} as FilledContext;
+
+  const html = renderToString(
+    <StrictMode>
+      <HelmetProvider context={helmetContext}>
+        <StaticRouter location={data.url}>
+          <App />
+        </StaticRouter>
+      </HelmetProvider>
+    </StrictMode>,
+  );
+
+  const { helmet } = helmetContext;
+  const crawledLinks = parseLinks(html);
+  const links = new Set([
+    ...crawledLinks,
+    ...PRERENDER_ROUTES.filter((route) => route !== data.url),
+  ]);
+
+  return {
+    html,
+    links,
+    head: helmet
+      ? {
+          lang: "de",
+          title: extractTitle(helmet),
+          elements: extractHeadElements(helmet),
+        }
+      : undefined,
+  };
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -22,14 +22,27 @@ import { useScrollIntent } from "@/hooks/useScrollIntent";
 ───────────────────────────────────────────────────────────── */
 const NUM_PARTICLES = 18;
 
-const gardenParticles = Array.from({ length: NUM_PARTICLES }, (_, i) => ({
-  id: i,
-  x: Math.random() * 100,
-  delay: Math.random() * 6,
-  duration: 7 + Math.random() * 8,
-  size: 3 + Math.random() * 5,
-  opacity: 0.18 + Math.random() * 0.28,
-}));
+function createSeededRandom(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 16807) % 2147483647;
+    return (state - 1) / 2147483646;
+  };
+}
+
+const gardenParticles = Array.from({ length: NUM_PARTICLES }, (_, i) => {
+  const random = createSeededRandom(i + 1);
+  return {
+    id: i,
+    x: random() * 100,
+    delay: random() * 6,
+    duration: 7 + random() * 8,
+    size: 3 + random() * 5,
+    opacity: 0.18 + random() * 0.28,
+    driftY: 260 + random() * 200,
+    driftX: (random() - 0.5) * 40,
+  };
+});
 
 const ComplimentVideoSection: React.FC = () => {
   const videoRef = React.useRef<HTMLVideoElement>(null);
@@ -122,9 +135,9 @@ const ComplimentVideoSection: React.FC = () => {
               filter: "blur(1px)",
             }}
             animate={{
-              y: [0, -(260 + Math.random() * 200)],
+              y: [0, -p.driftY],
               opacity: [0, p.opacity, p.opacity * 0.6, 0],
-              x: [0, (Math.random() - 0.5) * 40],
+              x: [0, p.driftX],
             }}
             transition={{
               duration: p.duration,

--- a/src/seo/prerenderRoutes.mjs
+++ b/src/seo/prerenderRoutes.mjs
@@ -1,0 +1,10 @@
+/** Routes emitted as prebuilt static HTML during production builds. */
+export const PRERENDER_ROUTES = [
+  "/",
+  "/for-students",
+  "/for-companies",
+  "/events",
+  "/privacy-policy",
+  "/imprint",
+  "/about",
+];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { vitePrerenderPlugin } from "vite-prerender-plugin";
 
 import path from "path";
+import { PRERENDER_ROUTES } from "./src/seo/prerenderRoutes.mjs";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    vitePrerenderPlugin({
+      renderTarget: "#root",
+      additionalPrerenderRoutes: PRERENDER_ROUTES,
+    }),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary

Adds build-time prerendering so each route is emitted as a static `index.html` file in `dist/`, while keeping the existing Vite + React Router SPA for client-side hydration and navigation.

## What changed

- **`vite-prerender-plugin`** — prerenders 7 routes at build time
- **`src/bootstrap.tsx`** — prerender entry + production `hydrateRoot`
- **`src/seo/prerenderRoutes.mjs`** — canonical route list
- **`scripts/verify-prerender.mjs`** — postbuild check that every route has real HTML + SEO meta
- **`src/pages/About.tsx`** — deterministic particle values (hydration-safe)
- **`src/App.tsx`** — `/about` route alias

## Prebuilt routes

`/`, `/for-students`, `/for-companies`, `/events`, `/privacy-policy`, `/imprint`, `/about`

## How it works

1. `vite build` bundles the SPA as before
2. The prerender plugin writes `dist/<route>/index.html` with full page markup and SEO tags
3. Netlify shadowing serves those files before the existing `/* → /index.html` SPA fallback
4. The client bundle hydrates on load — routing, i18n toggle, and analytics unchanged

## Verification

- `npm run build` prerenders all 7 routes
- Postbuild verification passes (5–89 KB HTML per route)
- `vite preview` serves prebuilt HTML with `<main>` content and meta tags

## Deployment note

No Netlify config changes required. Merging this PR triggers a normal production deploy.