### PR TITLE
feat(cta): add action CTAs to landing and for-companies pages

### DIFF
--- a/src/components/ScrollRestoration.tsx
+++ b/src/components/ScrollRestoration.tsx
@@ -12,12 +12,26 @@ const ScrollRestoration: React.FC = () => {
     if (prevPath.current) {
       scrollPositions.set(prevPath.current, window.scrollY);
     }
+
+    if (location.hash) {
+      const id = location.hash.slice(1);
+      const scrollToHash = () => {
+        const el = document.getElementById(id);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      };
+      requestAnimationFrame(scrollToHash);
+      prevPath.current = location.pathname;
+      return;
+    }
+
     // Restore scroll position for current path, or scroll to top
     const y = scrollPositions.get(location.pathname) ?? 0;
     window.scrollTo(0, y);
     prevPath.current = location.pathname;
     // Optionally, clean up positions for unmounted routes
-  }, [location.pathname]);
+  }, [location.pathname, location.hash]);
 
   return null;
 };

--- a/src/components/sections/GardenCtaPair.tsx
+++ b/src/components/sections/GardenCtaPair.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { motion, useInView, useReducedMotion } from "framer-motion";
 import { useScrollIntent } from "@/hooks/useScrollIntent";
+import { trackButtonClick } from "@/utils/analytics";
 
 export interface CtaSpec {
   label: string;
   href: string;
   variant: "solid" | "ghost";
+  /** Umami source label, e.g. "Landing — Alumni". */
+  trackingSource?: string;
 }
 
 interface Props {
@@ -16,6 +19,8 @@ interface Props {
   externalPlay?: boolean;
   /** Delay offset for the first button's bloom (seconds). */
   baseDelay?: number;
+  /** Show labels immediately — no scroll-intent or bloom delay. */
+  instant?: boolean;
 }
 
 /**
@@ -31,12 +36,22 @@ const GardenCta: React.FC<{
   reduce: boolean | null;
   index: number;
   baseDelay: number;
-}> = ({ spec, play, reduce, index, baseDelay }) => {
+  instant?: boolean;
+}> = ({ spec, play, reduce, index, baseDelay, instant = false }) => {
   const isSolid = spec.variant === "solid";
   const delay = baseDelay + index * 0.16;
 
+  const isExternal = /^https?:\/\//.test(spec.href);
   const isHash = spec.href.startsWith("#");
+
+  const trackClick = () => {
+    if (spec.trackingSource) {
+      trackButtonClick(spec.label, spec.trackingSource);
+    }
+  };
+
   const handleHashClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    trackClick();
     if (!isHash) return;
     const id = spec.href.slice(1);
     const el = document.getElementById(id);
@@ -49,7 +64,7 @@ const GardenCta: React.FC<{
   const inner = (
     <>
       {/* Soft halo (toned down) */}
-      {!reduce && (
+      {!reduce && !instant && (
         <motion.span
           aria-hidden="true"
           className={
@@ -70,7 +85,7 @@ const GardenCta: React.FC<{
       )}
 
       {/* Gold perimeter — solid button only */}
-      {isSolid && (
+      {isSolid && !instant && (
         <svg
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 h-full w-full overflow-visible"
@@ -116,57 +131,100 @@ const GardenCta: React.FC<{
         </svg>
       )}
 
-      <motion.span
-        className="relative z-10 flex items-center gap-2.5"
-        initial={{ opacity: 0, y: 6 }}
-        animate={play ? { opacity: 1, y: 0 } : { opacity: 0, y: 6 }}
-        transition={{
-          duration: reduce ? 0.01 : 0.6,
-          delay: reduce ? 0 : delay + 0.1,
-          ease: [0.16, 1, 0.3, 1],
-        }}
-      >
-        <span className="leading-none">{spec.label}</span>
-        {isHash ? (
-          /* Down chevron — visitor stays on page (scrolls to section) */
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 16 16"
-            className={
-              "h-3.5 w-3.5 shrink-0 transition-transform duration-300 ease-out group-hover:translate-y-0.5 " +
-              (isSolid ? "text-[#0B1730]" : "text-[#C69E3C]")
-            }
-          >
-            <path
-              d="M3 6l5 5 5-5"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        ) : (
-          /* Right arrow — visitor navigates to another page */
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 16 16"
-            className={
-              "h-3.5 w-3.5 shrink-0 transition-transform duration-300 ease-out group-hover:translate-x-0.5 " +
-              (isSolid ? "text-[#0B1730]" : "text-white")
-            }
-          >
-            <path
-              d="M3 8h9M8 4l4 4-4 4"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        )}
-      </motion.span>
+      {instant ? (
+        <span className="relative z-10 flex items-center gap-2.5">
+          <span className="leading-none">{spec.label}</span>
+          {isHash ? (
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 16 16"
+              className={
+                "h-3.5 w-3.5 shrink-0 transition-transform duration-300 ease-out group-hover:translate-y-0.5 " +
+                (isSolid ? "text-[#0B1730]" : "text-[#C69E3C]")
+              }
+            >
+              <path
+                d="M3 6l5 5 5-5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          ) : (
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 16 16"
+              className={
+                "h-3.5 w-3.5 shrink-0 transition-transform duration-300 ease-out group-hover:translate-x-0.5 " +
+                (isSolid ? "text-[#0B1730]" : "text-white")
+              }
+            >
+              <path
+                d="M3 8h9M8 4l4 4-4 4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
+        </span>
+      ) : (
+        <motion.span
+          className="relative z-10 flex items-center gap-2.5"
+          initial={{ opacity: 0, y: 6 }}
+          animate={play ? { opacity: 1, y: 0 } : { opacity: 0, y: 6 }}
+          transition={{
+            duration: reduce ? 0.01 : 0.6,
+            delay: reduce ? 0 : delay + 0.1,
+            ease: [0.16, 1, 0.3, 1],
+          }}
+        >
+          <span className="leading-none">{spec.label}</span>
+          {isHash ? (
+            /* Down chevron — visitor stays on page (scrolls to section) */
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 16 16"
+              className={
+                "h-3.5 w-3.5 shrink-0 transition-transform duration-300 ease-out group-hover:translate-y-0.5 " +
+                (isSolid ? "text-[#0B1730]" : "text-[#C69E3C]")
+              }
+            >
+              <path
+                d="M3 6l5 5 5-5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          ) : (
+            /* Right arrow — visitor navigates to another page */
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 16 16"
+              className={
+                "h-3.5 w-3.5 shrink-0 transition-transform duration-300 ease-out group-hover:translate-x-0.5 " +
+                (isSolid ? "text-[#0B1730]" : "text-white")
+              }
+            >
+              <path
+                d="M3 8h9M8 4l4 4-4 4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
+        </motion.span>
+      )}
     </>
   );
 
@@ -177,16 +235,38 @@ const GardenCta: React.FC<{
     ? " bg-[#C69E3C] text-[#0B1730] hover:bg-[#D9AE50] shadow-[0_0_18px_-10px_rgba(198,158,60,0.5)]"
     : " bg-[#0f2b57] text-white hover:bg-[#163d75]";
 
+  if (isExternal) {
+    return (
+      <a
+        href={spec.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={trackClick}
+        className={baseClass + surfaceClass}
+      >
+        {inner}
+      </a>
+    );
+  }
+
   if (isHash) {
     return (
-      <a href={spec.href} onClick={handleHashClick} className={baseClass + surfaceClass}>
+      <a
+        href={spec.href}
+        onClick={handleHashClick}
+        className={baseClass + surfaceClass}
+      >
         {inner}
       </a>
     );
   }
 
   return (
-    <Link to={spec.href} className={baseClass + surfaceClass}>
+    <Link
+      to={spec.href}
+      onClick={trackClick}
+      className={baseClass + surfaceClass}
+    >
       {inner}
     </Link>
   );
@@ -203,17 +283,25 @@ const GardenCtaPair: React.FC<Props> = ({
   className = "",
   externalPlay,
   baseDelay = 1.55,
+  instant = false,
 }) => {
   const ref = React.useRef<HTMLDivElement>(null);
   const inView = useInView(ref, { once: true, amount: 0.35 });
   const reduce = useReducedMotion();
   const internalPlay = useScrollIntent(inView, reduce);
-  const play = externalPlay !== undefined ? externalPlay : internalPlay;
+  const play = instant
+    ? true
+    : externalPlay !== undefined
+      ? externalPlay
+      : internalPlay;
+  const resolvedBaseDelay = instant ? 0 : baseDelay;
 
   return (
     <div
       ref={ref}
-      className={"relative flex flex-col gap-3 sm:flex-row sm:flex-wrap " + className}
+      className={
+        "relative flex flex-col gap-3 sm:flex-row sm:flex-wrap " + className
+      }
     >
       {items.map((item, i) => (
         <GardenCta
@@ -222,7 +310,8 @@ const GardenCtaPair: React.FC<Props> = ({
           play={play}
           reduce={reduce}
           index={i}
-          baseDelay={baseDelay}
+          baseDelay={resolvedBaseDelay}
+          instant={instant}
         />
       ))}
     </div>

--- a/src/components/sections/YblaJourney.tsx
+++ b/src/components/sections/YblaJourney.tsx
@@ -24,7 +24,11 @@ const YblaJourney: React.FC<YblaJourneyProps> = ({ isDe }) => {
           "Ausbildung der nächsten Führungsgenerationen: Wir bereiten junge Menschen auf Leitungsaufgaben im heimischen Wirtschaftsraum vor. Zentral dafür ist unsere YBLA. Ein intensives 18-monatiges Programm für Studierende und Berufseinsteiger. Zugrunde liegt ein erfolgreiches Schulungskonzept welches Theorie, Praxis und Projektverantwortung vereint. Unsere Auswahl ist strikt herkunftsblind: Wer Potenzial zeigt, unsere mathematisch-analytische und psychologische Eignungsdiagnostik besteht und sich konsequent anstrengt, erarbeitet sich seinen Weg.",
         stats: [
           { value: "18", unit: "Monate", note: "Programmdauer" },
-          { value: "10–18", unit: "h / Woche", note: "außerhalb der Prüfungsphasen" },
+          {
+            value: "10–18",
+            unit: "h / Woche",
+            note: "außerhalb der Prüfungsphasen",
+          },
         ],
       }
     : {
@@ -40,7 +44,10 @@ const YblaJourney: React.FC<YblaJourneyProps> = ({ isDe }) => {
       };
 
   return (
-    <section className="relative isolate overflow-hidden bg-[#040F1F] py-24 text-white md:py-32 lg:py-40">
+    <section
+      id="ybla"
+      className="relative isolate overflow-hidden bg-[#040F1F] py-24 text-white md:py-32 lg:py-40"
+    >
       {/* ambient glow */}
       <div
         aria-hidden="true"
@@ -69,7 +76,6 @@ const YblaJourney: React.FC<YblaJourneyProps> = ({ isDe }) => {
       </div>
 
       <div className="relative mx-auto w-full max-w-screen-xl px-6 md:px-12 lg:px-16">
-
         {/* ── kicker ── */}
         <motion.div
           initial={{ opacity: 0, x: -16 }}
@@ -83,7 +89,6 @@ const YblaJourney: React.FC<YblaJourneyProps> = ({ isDe }) => {
 
         {/* ── headline + intro + stats row ── */}
         <div className="flex flex-col gap-12 lg:flex-row lg:items-start lg:gap-16 xl:gap-24">
-
           {/* left: title + intro */}
           <div className="lg:w-[55%] xl:w-[58%]">
             <motion.h2
@@ -138,9 +143,7 @@ const YblaJourney: React.FC<YblaJourneyProps> = ({ isDe }) => {
               </div>
             </motion.div>
           </div>
-
         </div>
-
       </div>
     </section>
   );

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -13,6 +13,8 @@ import HeritageGardenSection from "@/components/sections/HeritageGardenSection";
 import OptimizedImage from "@/components/OptimizedImage";
 import { useScrollIntent } from "@/hooks/useScrollIntent";
 
+const APPLY_FORM_URL = "https://tally.so/r/yPDXd4";
+
 /* ─────────────────────────────────────────────────────────────
    ComplimentVideoSection
    Full-width autoplay video with an immersive garden-like overlay:
@@ -44,7 +46,7 @@ const gardenParticles = Array.from({ length: NUM_PARTICLES }, (_, i) => {
   };
 });
 
-const ComplimentVideoSection: React.FC = () => {
+const ComplimentVideoSection: React.FC<{ isDe: boolean }> = ({ isDe }) => {
   const videoRef = React.useRef<HTMLVideoElement>(null);
   const fallbackRef = React.useRef<HTMLImageElement>(null);
   const [muted, setMuted] = React.useState(true);
@@ -65,6 +67,8 @@ const ComplimentVideoSection: React.FC = () => {
     const video = videoRef.current;
     if (!video) return;
     video.currentTime = 0;
+    if (fallbackRef.current) fallbackRef.current.style.display = "none";
+    if (videoRef.current) videoRef.current.style.display = "block";
     video.play();
     setVideoEnded(false);
   };
@@ -149,9 +153,46 @@ const ComplimentVideoSection: React.FC = () => {
         ))}
       </div>
 
+      {/* ── Action CTAs — only after video ends (static image) ── */}
+      <AnimatePresence>
+        {videoEnded && (
+          <motion.div
+            key="video-ctas"
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+            className="pointer-events-none absolute inset-x-0 bottom-14 z-20 flex justify-center px-4 sm:bottom-16 md:bottom-20"
+          >
+            <div className="pointer-events-auto w-full max-w-md sm:max-w-none">
+              <GardenCtaPair
+                instant
+                className="w-full justify-center"
+                items={[
+                  {
+                    label: isDe ? "Jetzt bewerben" : "Apply now",
+                    href: APPLY_FORM_URL,
+                    variant: "solid",
+                    trackingSource: "Landing — Video",
+                  },
+                  {
+                    label: isDe
+                      ? "Gespräch vereinbaren"
+                      : "Schedule a conversation",
+                    href: "/for-companies#contact",
+                    variant: "ghost",
+                    trackingSource: "Landing — Video",
+                  },
+                ]}
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       {/* ── Attribution ─────────────────────────────────────── */}
       <div
-        className="pointer-events-none absolute bottom-6 left-6 md:bottom-8 md:left-10"
+        className="pointer-events-none absolute bottom-3 left-4 md:bottom-8 md:left-10 max-w-[42%] sm:max-w-none"
         style={{ zIndex: 10 }}
       >
         <p
@@ -167,10 +208,7 @@ const ComplimentVideoSection: React.FC = () => {
       </div>
 
       {/* ── Sound toggle (video) / Replay button (image) ──── */}
-      <div
-        className="absolute bottom-6 right-6 md:bottom-8 md:right-10"
-        style={{ zIndex: 10 }}
-      >
+      <div className="absolute bottom-6 right-6 z-30 md:bottom-8 md:right-10">
         <AnimatePresence>
           {showHint && !videoEnded && (
             <motion.span
@@ -1373,6 +1411,36 @@ const About: React.FC = () => {
               </div>
             ))}
           </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 32 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-60px" }}
+            transition={{
+              duration: 0.85,
+              delay: 0.2,
+              ease: [0.22, 1, 0.36, 1],
+            }}
+            className="mt-16"
+          >
+            <GardenCtaPair
+              instant
+              items={[
+                {
+                  label: isDe ? "Jetzt bewerben" : "Apply now",
+                  href: APPLY_FORM_URL,
+                  variant: "solid",
+                  trackingSource: "Landing — Alumni",
+                },
+                {
+                  label: isDe ? "Partner werden" : "Become a partner",
+                  href: "/for-companies#contact",
+                  variant: "ghost",
+                  trackingSource: "Landing — Alumni",
+                },
+              ]}
+            />
+          </motion.div>
         </div>
       </section>
 
@@ -1439,12 +1507,35 @@ const About: React.FC = () => {
                 ? "Jeder Bewerber durchläuft dasselbe Verfahren - unabhängig von Herkunft oder Netzwerk. Bewertet werden analytisches Denken, Leistungsbereitschaft und Führungscharakter: die Fähigkeit, Initiative zu ergreifen, zu führen und geführt zu werden."
                 : "Every applicant goes through the same process — regardless of background or network. We assess analytical thinking, drive, and leadership character: the ability to take initiative, to lead, and to be led."}
             </motion.p>
+            <motion.div
+              initial={{ opacity: 0, y: 28 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-60px" }}
+              transition={{
+                duration: 0.85,
+                delay: 0.35,
+                ease: [0.22, 1, 0.36, 1],
+              }}
+              className="mt-10"
+            >
+              <GardenCtaPair
+                instant
+                items={[
+                  {
+                    label: isDe ? "Jetzt bewerben" : "Apply now",
+                    href: APPLY_FORM_URL,
+                    variant: "solid",
+                    trackingSource: "Landing — Selection",
+                  },
+                ]}
+              />
+            </motion.div>
           </div>
         </div>
       </section>
 
       {/* §6b — Compliment video: full-width immersive */}
-      <ComplimentVideoSection />
+      <ComplimentVideoSection isDe={isDe} />
     </div>
   );
 };

--- a/src/pages/ForCompanies.tsx
+++ b/src/pages/ForCompanies.tsx
@@ -8,6 +8,10 @@ import {
   ArrowUpRight,
   Mic2,
 } from "lucide-react";
+import { trackButtonClick } from "../utils/analytics";
+
+const ACTION_CTA_CLASS =
+  "bg-[#B7860B] text-[#0A1628] px-12 py-5 font-black uppercase tracking-widest text-sm flex items-center gap-4 shadow-[0_0_40px_rgba(183,134,11,0.3)] inline-flex";
 
 // --- HILFSKOMPONENTE: COUNTER ---
 const Counter = ({ value }: { value: string }) => {
@@ -184,6 +188,16 @@ const ForCompanies: React.FC = () => {
             der Nächsten <br />
             Generation.
           </h2>
+          <motion.a
+            href="#contact"
+            onClick={() =>
+              trackButtonClick("Gespräch vereinbaren", "For Companies — Hero")
+            }
+            whileHover={{ scale: 1.05 }}
+            className={`${ACTION_CTA_CLASS} mt-10`}
+          >
+            Gespräch vereinbaren <ArrowUpRight size={20} />
+          </motion.a>
         </div>
       </section>
 
@@ -362,6 +376,21 @@ const ForCompanies: React.FC = () => {
               </AnimatePresence>
             </div>
           </div>
+          <div className="mt-16 flex justify-center">
+            <motion.a
+              href="#contact"
+              onClick={() =>
+                trackButtonClick(
+                  "Als Speaker einbringen",
+                  "For Companies — Leadership Forge",
+                )
+              }
+              whileHover={{ scale: 1.05 }}
+              className={ACTION_CTA_CLASS}
+            >
+              Als Speaker einbringen <Mic2 size={20} />
+            </motion.a>
+          </div>
         </div>
       </section>
 
@@ -533,6 +562,21 @@ const ForCompanies: React.FC = () => {
                 );
               })}
             </div>
+          </div>
+          <div className="mt-12 flex justify-center">
+            <motion.a
+              href="#contact"
+              onClick={() =>
+                trackButtonClick(
+                  "Jetzt Gespräch vereinbaren",
+                  "For Companies — Testimonials",
+                )
+              }
+              whileHover={{ scale: 1.05 }}
+              className={ACTION_CTA_CLASS}
+            >
+              Jetzt Gespräch vereinbaren <ArrowUpRight size={20} />
+            </motion.a>
           </div>
         </div>
       </section>

--- a/src/pages/ForCompanies.tsx
+++ b/src/pages/ForCompanies.tsx
@@ -6,12 +6,8 @@ import {
   ChevronRight,
   ChevronLeft,
   ArrowUpRight,
-  Mic2,
 } from "lucide-react";
-import { trackButtonClick } from "../utils/analytics";
-
-const ACTION_CTA_CLASS =
-  "bg-[#B7860B] text-[#0A1628] px-12 py-5 font-black uppercase tracking-widest text-sm flex items-center gap-4 shadow-[0_0_40px_rgba(183,134,11,0.3)] inline-flex";
+import GardenCtaPair from "@/components/sections/GardenCtaPair";
 
 // --- HILFSKOMPONENTE: COUNTER ---
 const Counter = ({ value }: { value: string }) => {
@@ -177,35 +173,38 @@ const ForCompanies: React.FC = () => {
           alt="Hero"
           className="w-full h-full absolute inset-0 object-cover opacity-60"
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-[#0A1628]/90 via-transparent to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-t from-[#040F1F]/90 via-transparent to-transparent" />
         <div className="relative z-10 container-custom px-4 md:px-8 mx-auto w-full pb-20">
-          <span className="text-[#B7860B] font-black uppercase tracking-[0.4em] text-[10px] mb-2 block">
+          <span className="text-[#F6D77B] font-black uppercase tracking-[0.4em] text-[10px] mb-2 block">
             Your Legacy
           </span>
           <h2 className="text-6xl md:text-[8rem] font-black uppercase tracking-tighter leading-[0.75] text-white -ml-1">
             Tritt in den <br />
-            <span className="text-[#B7860B]">Austausch mit</span> <br />
+            <span className="text-[#F6D77B]">Austausch mit</span> <br />
             der Nächsten <br />
             Generation.
           </h2>
-          <motion.a
-            href="#contact"
-            onClick={() =>
-              trackButtonClick("Gespräch vereinbaren", "For Companies — Hero")
-            }
-            whileHover={{ scale: 1.05 }}
-            className={`${ACTION_CTA_CLASS} mt-10`}
-          >
-            Gespräch vereinbaren <ArrowUpRight size={20} />
-          </motion.a>
+          <div className="mt-10">
+            <GardenCtaPair
+              instant
+              items={[
+                {
+                  label: "Gespräch vereinbaren",
+                  href: "#contact",
+                  variant: "solid",
+                  trackingSource: "For Companies — Hero",
+                },
+              ]}
+            />
+          </div>
         </div>
       </section>
 
       {/* GOLDENER LINIEN VERLAUF 1 */}
-      <div className="h-px w-full bg-gradient-to-r from-transparent via-[#B7860B]/40 to-transparent bg-[#0A1628]" />
+      <div className="h-px w-full bg-gradient-to-r from-transparent via-[#F6D77B]/40 to-transparent bg-[#040F1F]" />
 
       {/* 2. MISSION (IMPACT) */}
-      <section className="py-32 bg-[#0A1628] relative overflow-hidden border-t border-white/5">
+      <section className="py-32 bg-[#040F1F] relative overflow-hidden border-t border-white/5">
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-[12rem] md:text-[20rem] font-black text-white/[0.02] select-none pointer-events-none uppercase tracking-tighter">
           Impact
         </div>
@@ -214,7 +213,7 @@ const ForCompanies: React.FC = () => {
             <div className="lg:col-span-6 space-y-12 text-left">
               <h2 className="text-4xl md:text-7xl font-black uppercase tracking-tighter leading-[0.85] text-white">
                 Von den Besten <br />
-                <span className="text-[#B7860B]">an die Besten.</span>
+                <span className="text-[#F6D77B]">an die Besten.</span>
               </h2>
               <div className="flex flex-wrap gap-x-20 gap-y-6">
                 {[
@@ -226,7 +225,7 @@ const ForCompanies: React.FC = () => {
                     <div className="text-4xl font-black text-white">
                       <Counter value={s.v} />
                     </div>
-                    <div className="text-[10px] font-black uppercase tracking-widest text-[#B7860B]">
+                    <div className="text-[10px] font-black uppercase tracking-widest text-[#F6D77B]">
                       {s.l}
                     </div>
                   </div>
@@ -238,23 +237,23 @@ const ForCompanies: React.FC = () => {
                   alt="Mission"
                   className="w-full h-full object-cover grayscale-[0.3] group-hover:grayscale-0 transition-all duration-1000 scale-105 group-hover:scale-100"
                 />
-                <div className="absolute inset-0 bg-gradient-to-t from-[#0A1628]/40 to-transparent" />
+                <div className="absolute inset-0 bg-gradient-to-t from-[#040F1F]/40 to-transparent" />
               </div>
             </div>
             <div className="lg:col-span-6 pt-12 md:pt-24 text-left">
               <div className="relative text-left">
-                <span className="text-[#B7860B] font-black uppercase tracking-[0.5em] text-[10px] mb-8 block">
+                <span className="text-[#F6D77B] font-black uppercase tracking-[0.5em] text-[10px] mb-8 block">
                   The Responsibility
                 </span>
                 <h3 className="text-5xl md:text-[5.5rem] font-black text-white leading-[0.95] mb-12 tracking-[0.02em] uppercase">
                   Die Zukunft <br />
-                  <span className="text-[#B7860B] tracking-[0.05em]">
+                  <span className="text-[#F6D77B] tracking-[0.05em]">
                     unserer
                   </span>{" "}
                   <br />
                   <motion.span
                     animate={{
-                      color: ["#FFFFFF", "#B7860B", "#D4AF37", "#FFFFFF"],
+                      color: ["#FFFFFF", "#F6D77B", "#C69E3C", "#FFFFFF"],
                     }}
                     transition={{
                       duration: 6,
@@ -277,17 +276,17 @@ const ForCompanies: React.FC = () => {
                   href="#contact"
                   className="group flex items-center gap-8 cursor-pointer text-left"
                 >
-                  <div className="w-24 h-24 rounded-full bg-[#B7860B] group-hover:bg-white transition-all duration-700 flex items-center justify-center shadow-2xl">
+                  <div className="w-24 h-24 rounded-full bg-[#C69E3C] group-hover:bg-white transition-all duration-700 flex items-center justify-center shadow-2xl">
                     <ArrowUpRight
                       size={40}
-                      className="text-[#0A1628] group-hover:rotate-45 transition-all duration-500"
+                      className="text-[#0B1730] group-hover:rotate-45 transition-all duration-500"
                     />
                   </div>
                   <div className="flex flex-col text-left">
-                    <span className="text-3xl font-black uppercase tracking-tighter text-white group-hover:text-[#B7860B] transition-colors">
+                    <span className="text-3xl font-black uppercase tracking-tighter text-white group-hover:text-[#F6D77B] transition-colors">
                       Mentor werden
                     </span>
-                    <span className="text-[#B7860B] text-[10px] font-bold uppercase tracking-widest mt-1">
+                    <span className="text-[#F6D77B] text-[10px] font-bold uppercase tracking-widest mt-1">
                       Jetzt starten
                     </span>
                   </div>
@@ -299,14 +298,14 @@ const ForCompanies: React.FC = () => {
       </section>
 
       {/* GOLDENER LINIEN VERLAUF 2 */}
-      <div className="h-px w-full bg-gradient-to-r from-transparent via-[#B7860B]/40 to-transparent bg-[#0A1628]" />
+      <div className="h-px w-full bg-gradient-to-r from-transparent via-[#F6D77B]/40 to-transparent bg-[#040F1F]" />
 
       {/* 3. LEADERSHIP FORGE (SLIDER) */}
-      <section className="py-24 bg-[#0A1628] text-white relative overflow-hidden text-left">
+      <section className="py-24 bg-[#040F1F] text-white relative overflow-hidden text-left">
         <div className="container-custom px-4 md:px-8 mx-auto relative z-10">
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-16 items-center">
             <div className="lg:col-span-7 relative group text-left">
-              <div className="relative aspect-video w-full overflow-hidden shadow-[30px_30px_0px_0px_#B7860B]">
+              <div className="relative aspect-video w-full overflow-hidden shadow-[30px_30px_0px_0px_#C69E3C]">
                 <AnimatePresence mode="wait">
                   <motion.img
                     key={currentSlide}
@@ -324,7 +323,7 @@ const ForCompanies: React.FC = () => {
                 >
                   <ChevronLeft
                     size={36}
-                    className="text-[#B7860B] group-hover/btn:scale-110 transition-transform"
+                    className="text-[#C69E3C] group-hover/btn:scale-110 transition-transform"
                   />
                 </button>
                 <button
@@ -333,7 +332,7 @@ const ForCompanies: React.FC = () => {
                 >
                   <ChevronRight
                     size={36}
-                    className="text-[#B7860B] group-hover/btn:scale-110 transition-transform"
+                    className="text-[#C69E3C] group-hover/btn:scale-110 transition-transform"
                   />
                 </button>
               </div>
@@ -348,7 +347,7 @@ const ForCompanies: React.FC = () => {
                   className="flex flex-col"
                 >
                   <div className="mb-12 text-left text-left">
-                    <span className="text-[#B7860B] text-xl italic font-serif mb-2 block">
+                    <span className="text-[#C69E3C] text-xl italic font-serif mb-2 block">
                       {academySlides[currentSlide].category}
                     </span>
                     <h3 className="text-4xl md:text-5xl font-black uppercase tracking-tighter leading-[0.9] text-white">
@@ -358,10 +357,10 @@ const ForCompanies: React.FC = () => {
                   <div className="space-y-12">
                     {academySlides[currentSlide].points.map((point, i) => (
                       <div key={i} className="flex gap-8 group text-left">
-                        <span className="text-4xl font-black text-[#B7860B] opacity-40">
+                        <span className="text-4xl font-black text-[#C69E3C] opacity-40">
                           {point.num}
                         </span>
-                        <div className="relative pl-6 border-l-2 border-[#B7860B]/30 pb-1">
+                        <div className="relative pl-6 border-l-2 border-[#C69E3C]/30 pb-1">
                           <h4 className="text-xl font-bold uppercase tracking-tight mb-2 text-white">
                             {point.title}
                           </h4>
@@ -377,19 +376,18 @@ const ForCompanies: React.FC = () => {
             </div>
           </div>
           <div className="mt-16 flex justify-center">
-            <motion.a
-              href="#contact"
-              onClick={() =>
-                trackButtonClick(
-                  "Als Speaker einbringen",
-                  "For Companies — Leadership Forge",
-                )
-              }
-              whileHover={{ scale: 1.05 }}
-              className={ACTION_CTA_CLASS}
-            >
-              Als Speaker einbringen <Mic2 size={20} />
-            </motion.a>
+            <GardenCtaPair
+              instant
+              className="justify-center"
+              items={[
+                {
+                  label: "Als Speaker einbringen",
+                  href: "#contact",
+                  variant: "solid",
+                  trackingSource: "For Companies — Leadership Forge",
+                },
+              ]}
+            />
           </div>
         </div>
       </section>
@@ -402,20 +400,20 @@ const ForCompanies: React.FC = () => {
             alt="Speaker Background"
             className="w-full h-full object-cover"
           />
-          <div className="absolute inset-0 bg-gradient-to-r from-[#0A1628] via-[#0A1628]/90 to-[#0A1628]/70 backdrop-blur-[1px]" />
+          <div className="absolute inset-0 bg-gradient-to-r from-[#040F1F] via-[#040F1F]/90 to-[#040F1F]/70 backdrop-blur-[1px]" />
         </div>
         <div className="container-custom px-4 md:px-8 mx-auto relative z-10 text-left">
           <div className="max-w-5xl">
             <div className="flex items-center gap-6 mb-8 text-left">
-              <div className="w-16 h-[2px] bg-[#B7860B]" />
-              <span className="text-[#B7860B] font-black uppercase tracking-[0.3em] text-sm text-left">
+              <div className="w-16 h-[2px] bg-[#F6D77B]" />
+              <span className="text-[#F6D77B] font-black uppercase tracking-[0.3em] text-sm text-left">
                 Leave your impact
               </span>
             </div>
             <h2 className="text-5xl md:text-8xl font-black text-white uppercase tracking-tighter leading-none mb-12 text-left">
               Engagieren sie sich <br />
               <span
-                className="text-transparent border-b-4 border-[#B7860B] pb-2 text-left"
+                className="text-transparent border-b-4 border-[#F6D77B] pb-2 text-left"
                 style={{ WebkitTextStroke: "1px white" }}
               >
                 als Speaker.
@@ -427,17 +425,21 @@ const ForCompanies: React.FC = () => {
                   Formen sie jetzt als Speaker mit ihrer Erfahrung und ihrem
                   Input die Generation ambitionierter künftiger Führungskräfte!
                 </p>
-                <motion.a
-                  href="#contact"
-                  whileHover={{ scale: 1.05 }}
-                  className="bg-[#B7860B] text-[#0A1628] px-12 py-5 font-black uppercase tracking-widest text-sm flex items-center gap-4 shadow-[0_0_40px_rgba(183,134,11,0.3)] inline-flex"
-                >
-                  Jetzt Speaker werden <Mic2 size={20} />
-                </motion.a>
+                <GardenCtaPair
+                  instant
+                  items={[
+                    {
+                      label: "Jetzt Speaker werden",
+                      href: "#contact",
+                      variant: "solid",
+                      trackingSource: "For Companies — Speaker",
+                    },
+                  ]}
+                />
               </div>
               <div className="flex flex-col gap-8 text-left text-left text-left">
                 <div className="group cursor-default border-l border-white/10 pl-8">
-                  <span className="text-[#B7860B] font-black text-xs uppercase tracking-widest block mb-2 text-left">
+                  <span className="text-[#C69E3C] font-black text-xs uppercase tracking-widest block mb-2 text-left">
                     Audienz
                   </span>
                   <p className="text-white text-lg font-bold tracking-tight uppercase">
@@ -445,7 +447,7 @@ const ForCompanies: React.FC = () => {
                   </p>
                 </div>
                 <div className="group cursor-default border-l border-white/10 pl-8">
-                  <span className="text-[#B7860B] font-black text-xs uppercase tracking-widest block mb-2 text-left text-left">
+                  <span className="text-[#C69E3C] font-black text-xs uppercase tracking-widest block mb-2 text-left text-left">
                     Format
                   </span>
                   <p className="text-white text-lg font-bold tracking-tight uppercase text-left">
@@ -461,27 +463,32 @@ const ForCompanies: React.FC = () => {
       {/* 5. ABOUT US LINK */}
       <section className="py-20 bg-white text-center overflow-hidden">
         <div className="container-custom px-4 md:px-8 mx-auto flex flex-col items-center text-center">
-          <span className="text-[#B7860B] font-black uppercase tracking-[0.4em] text-[10px] mb-6 block text-center">
+          <span className="text-[#F6D77B] font-black uppercase tracking-[0.4em] text-[10px] mb-6 block text-center">
             Establishing Entrepreneurs Since 1986
           </span>
-          <h2 className="text-4xl md:text-6xl font-black uppercase tracking-tighter leading-[1.0] mb-12 text-[#0F2B57] text-center">
+          <h2 className="text-4xl md:text-6xl font-black uppercase tracking-tighter leading-[1.0] mb-12 text-[#061D38] text-center">
             Vom Hörsaal zum{" "}
             <motion.span
-              animate={{ color: ["#0F2B57", "#B7860B", "#D4AF37", "#0F2B57"] }}
+              animate={{ color: ["#061D38", "#F6D77B", "#C69E3C", "#061D38"] }}
               transition={{ duration: 6, repeat: Infinity, ease: "linear" }}
               className="inline-block text-center"
             >
               Top-Management.
             </motion.span>
           </h2>
-          <div className="w-full flex justify-center text-center text-center text-center">
-            <motion.a
-              href="/about"
-              whileHover={{ scale: 1.01 }}
-              className="w-full max-w-5xl bg-[#B7860B] text-[#0F2B57] py-4 md:py-6 font-black uppercase tracking-[0.2em] shadow-xl flex items-center justify-center gap-4 text-center"
-            >
-              Mehr über uns erfahren <ArrowUpRight size={24} />
-            </motion.a>
+          <div className="flex justify-center">
+            <GardenCtaPair
+              instant
+              className="justify-center"
+              items={[
+                {
+                  label: "Mehr über uns erfahren",
+                  href: "/about#ybla",
+                  variant: "solid",
+                  trackingSource: "For Companies — About Link",
+                },
+              ]}
+            />
           </div>
         </div>
       </section>
@@ -490,12 +497,12 @@ const ForCompanies: React.FC = () => {
       <section className="py-12 bg-white relative overflow-hidden border-t border-slate-100 text-left text-left text-left">
         <div className="container-custom px-4 md:px-8 mx-auto relative z-10 text-left">
           <div className="flex items-center gap-4 mb-16 text-left text-left">
-            <span className="text-[#B7860B] font-black uppercase tracking-[0.4em] text-[10px] whitespace-nowrap text-left text-left text-left">
+            <span className="text-[#F6D77B] font-black uppercase tracking-[0.4em] text-[10px] whitespace-nowrap text-left text-left text-left">
               Testimonials
             </span>
-            <h2 className="text-3xl md:text-5xl font-black uppercase tracking-tighter text-[#0F2B57] whitespace-nowrap text-left text-left text-left text-left text-left">
+            <h2 className="text-3xl md:text-5xl font-black uppercase tracking-tighter text-[#061D38] whitespace-nowrap text-left text-left text-left text-left text-left">
               WAS{" "}
-              <span className="text-[#B7860B] text-left text-left">ANDERE</span>{" "}
+              <span className="text-[#F6D77B] text-left text-left">ANDERE</span>{" "}
               ÜBER UNS SAGEN.
             </h2>
             <div className="h-[1px] bg-slate-200 flex-grow" />
@@ -503,20 +510,20 @@ const ForCompanies: React.FC = () => {
           <div className="relative h-[550px] flex items-center justify-center text-center text-center">
             <button
               onClick={prevRef}
-              className="absolute left-0 md:left-4 z-50 w-12 h-12 bg-white shadow-xl rounded-full flex items-center justify-center border border-[#B7860B]/30 hover:bg-[#B7860B] group transition-all text-center text-center"
+              className="absolute left-0 md:left-4 z-50 w-12 h-12 bg-white shadow-xl rounded-full flex items-center justify-center border border-[#C69E3C]/30 hover:bg-[#C69E3C] group transition-all text-center text-center"
             >
               <ChevronLeft
                 size={24}
-                className="text-[#B7860B] group-hover:text-white"
+                className="text-[#C69E3C] group-hover:text-white"
               />
             </button>
             <button
               onClick={nextRef}
-              className="absolute right-0 md:right-4 z-50 w-12 h-12 bg-white shadow-xl rounded-full flex items-center justify-center border border-[#B7860B]/30 hover:bg-[#B7860B] group transition-all text-center text-center"
+              className="absolute right-0 md:right-4 z-50 w-12 h-12 bg-white shadow-xl rounded-full flex items-center justify-center border border-[#C69E3C]/30 hover:bg-[#C69E3C] group transition-all text-center text-center"
             >
               <ChevronRight
                 size={24}
-                className="text-[#B7860B] group-hover:text-white"
+                className="text-[#C69E3C] group-hover:text-white"
               />
             </button>
             <div className="relative w-full max-w-6xl h-full flex items-center justify-center text-center text-center">
@@ -538,9 +545,9 @@ const ForCompanies: React.FC = () => {
                       zIndex: isActive ? 30 : 10,
                     }}
                     transition={{ duration: 0.6, ease: [0.23, 1, 0.32, 1] }}
-                    className="absolute w-full max-w-[400px] bg-[#F8FAFC] p-10 shadow-2xl border-t-4 border-[#B7860B] flex flex-col items-center text-center text-center text-center"
+                    className="absolute w-full max-w-[400px] bg-[#F8FAFC] p-10 shadow-2xl border-t-4 border-[#C69E3C] flex flex-col items-center text-center text-center text-center"
                   >
-                    <div className="w-24 h-24 rounded-full mb-8 overflow-hidden border-2 border-[#B7860B]/20 bg-slate-200 text-center">
+                    <div className="w-24 h-24 rounded-full mb-8 overflow-hidden border-2 border-[#C69E3C]/20 bg-slate-200 text-center">
                       <img
                         src={test.img}
                         className="w-full h-full object-cover text-center"
@@ -551,10 +558,10 @@ const ForCompanies: React.FC = () => {
                       "{test.quote}"
                     </p>
                     <div className="text-center text-center">
-                      <h4 className="text-lg font-black text-[#0F2B57] uppercase tracking-tight text-center">
+                      <h4 className="text-lg font-black text-[#061D38] uppercase tracking-tight text-center">
                         {test.author}
                       </h4>
-                      <p className="text-[#B7860B] font-bold uppercase tracking-widest text-[9px] mt-1 text-center">
+                      <p className="text-[#C69E3C] font-bold uppercase tracking-widest text-[9px] mt-1 text-center">
                         {test.position}
                       </p>
                     </div>
@@ -564,19 +571,18 @@ const ForCompanies: React.FC = () => {
             </div>
           </div>
           <div className="mt-12 flex justify-center">
-            <motion.a
-              href="#contact"
-              onClick={() =>
-                trackButtonClick(
-                  "Jetzt Gespräch vereinbaren",
-                  "For Companies — Testimonials",
-                )
-              }
-              whileHover={{ scale: 1.05 }}
-              className={ACTION_CTA_CLASS}
-            >
-              Jetzt Gespräch vereinbaren <ArrowUpRight size={20} />
-            </motion.a>
+            <GardenCtaPair
+              instant
+              className="justify-center"
+              items={[
+                {
+                  label: "Jetzt Gespräch vereinbaren",
+                  href: "#contact",
+                  variant: "solid",
+                  trackingSource: "For Companies — Testimonials",
+                },
+              ]}
+            />
           </div>
         </div>
       </section>
@@ -612,9 +618,9 @@ const ForCompanies: React.FC = () => {
               className="w-full h-full object-cover"
             />
           </div>
-          <div className="md:w-1/2 w-full bg-[#0F2B57] p-10 md:p-16 flex flex-col justify-center text-white text-left">
+          <div className="md:w-1/2 w-full bg-[#040F1F] p-10 md:p-16 flex flex-col justify-center text-white text-left">
             <div className="flex gap-4 mb-10 text-left">
-              <div className="w-[3px] bg-[#B7860B] text-left" />
+              <div className="w-[3px] bg-[#F6D77B] text-left" />
               <p className="italic text-2xl text-slate-200 leading-tight text-left">
                 “Falls Sie Fragen haben oder sich engagieren möchten, melden Sie
                 sich gerne!”
@@ -624,7 +630,7 @@ const ForCompanies: React.FC = () => {
               <h3 className="text-2xl font-bold mb-1 text-white uppercase tracking-tight">
                 Jonathan Babelotzky
               </h3>
-              <p className="text-[#B7860B] text-[10px] font-black uppercase tracking-[0.2em] text-left">
+              <p className="text-[#F6D77B] text-[10px] font-black uppercase tracking-[0.2em] text-left">
                 {" "}
                 Bereichsleiter Strategie und Partnerschaften
               </p>
@@ -632,13 +638,13 @@ const ForCompanies: React.FC = () => {
             <div className="flex gap-12 text-left">
               <a
                 href="https://www.linkedin.com/in/jonathan-babelotzky/"
-                className="flex items-center gap-3 text-white hover:text-[#B7860B] text-xs font-black uppercase transition-colors text-left"
+                className="flex items-center gap-3 text-white hover:text-[#F6D77B] text-xs font-black uppercase transition-colors text-left"
               >
                 <Linkedin size={32} /> LinkedIn
               </a>
               <a
                 href="mailto:jonathan.babelotzky@teg-ev.de"
-                className="flex items-center gap-3 text-white hover:text-[#B7860B] text-xs font-black uppercase transition-colors text-left"
+                className="flex items-center gap-3 text-white hover:text-[#F6D77B] text-xs font-black uppercase transition-colors text-left"
               >
                 <Mail size={32} /> Email
               </a>


### PR DESCRIPTION
Integrate conversion CTAs at high-intent sections on For Companies (hero, leadership forge, testimonials) and landing (alumni, selection, post-video overlay). Extend GardenCtaPair with instant labels, external links, and analytics tracking. Fix hash scroll for /for-companies#contact deep links.